### PR TITLE
feat(browser): add model selection dropdown to chat sender footer [AI]

### DIFF
--- a/src/components/ChatSender/SenderFooter/ModelSelect.tsx
+++ b/src/components/ChatSender/SenderFooter/ModelSelect.tsx
@@ -1,0 +1,145 @@
+import { useRequest } from 'ahooks';
+import { Input, Select } from 'antd';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSnapshot } from 'valtio';
+import { state as chatState } from '@/state/chat';
+import { actions, state } from '@/state/config';
+import SenderComponent from '../SenderComponent';
+
+const ModelSelect = () => {
+  const { t } = useTranslation();
+  const { config } = useSnapshot(state);
+  const { cwd, initialized } = useSnapshot(chatState);
+  const [searchText, setSearchText] = useState('');
+
+  const { loading, data } = useRequest(
+    () => {
+      return actions.getModelsList();
+    },
+    {
+      ready: !!cwd && initialized, // Only call API when cwd exists and is initialized
+      refreshDeps: [cwd, initialized],
+      onSuccess: async () => {
+        await actions.getConfig();
+      },
+    },
+  );
+
+  const modelsList = useMemo(() => {
+    if (data?.success) {
+      return data.data.groupedModels;
+    }
+    return [];
+  }, [data]);
+
+  const filteredModelsList = useMemo(() => {
+    if (!searchText.trim()) {
+      return modelsList;
+    }
+
+    return modelsList
+      .map((providerGroup) => ({
+        ...providerGroup,
+        models: providerGroup.models.filter(
+          (model) =>
+            model.name.toLowerCase().includes(searchText.toLowerCase()) ||
+            model.value.toLowerCase().includes(searchText.toLowerCase()),
+        ),
+      }))
+      .filter((providerGroup) => providerGroup.models.length > 0);
+  }, [modelsList, searchText]);
+
+  const customDropdown = (menu: React.ReactElement) => (
+    <div className="w-full min-w-[280px]">
+      <div className="px-3 py-2 bg-white">
+        <Input
+          placeholder={t('chat.searchModel', 'Search models')}
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          className="border-none shadow-none"
+          style={{
+            backgroundColor: 'transparent',
+            border: 'none',
+            boxShadow: 'none',
+            paddingLeft: 0,
+            paddingRight: 0,
+          }}
+          autoFocus
+        />
+      </div>
+      <div
+        className="max-h-60 overflow-y-auto bg-white"
+        style={{
+          scrollbarWidth: 'thin',
+          scrollbarColor: '#d1d5db transparent',
+        }}
+      >
+        {filteredModelsList.length === 0 ? (
+          <div className="p-4 text-center text-gray-500">
+            {t('chat.noModelsFound', 'No models found')}
+          </div>
+        ) : (
+          menu
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <SenderComponent.Select
+      value={config?.model}
+      onChange={(value) => {
+        actions.set('model', value);
+        setSearchText(''); // Clear search when selecting
+      }}
+      loading={loading}
+      popupMatchSelectWidth={false}
+      placeholder={t('chat.selectModel')}
+      className="min-w-[140px]"
+      optionLabelProp="label"
+      showSearch={false} // Disable default search as we have custom search
+      filterOption={false} // Disable default filtering
+      dropdownRender={customDropdown}
+      onDropdownVisibleChange={(open) => {
+        if (!open) {
+          setSearchText(''); // Clear search when closing dropdown
+        }
+      }}
+    >
+      {filteredModelsList.map((providerGroup) => (
+        <Select.OptGroup
+          key={providerGroup.providerId}
+          label={
+            <div className="text-xs font-semibold text-gray-500 uppercase tracking-wider px-0 py-1">
+              {providerGroup.provider}
+            </div>
+          }
+        >
+          {providerGroup.models.map((model) => (
+            <Select.Option
+              key={model.value}
+              value={model.value}
+              label={
+                <div className="flex items-center gap-2">
+                  <span className="text-xs bg-gray-100 px-1.5 py-0.5 rounded ml-1">
+                    {providerGroup.provider}
+                  </span>
+                  {model.name}
+                </div>
+              }
+            >
+              <div className="px-0 py-1">
+                <span className="text-sm text-gray-900 font-medium">
+                  {model.name}
+                </span>
+              </div>
+            </Select.Option>
+          ))}
+        </Select.OptGroup>
+      ))}
+    </SenderComponent.Select>
+  );
+};
+
+export default ModelSelect;

--- a/src/components/ChatSender/SenderFooter/index.tsx
+++ b/src/components/ChatSender/SenderFooter/index.tsx
@@ -4,6 +4,7 @@ import McpDropdown from '@/components/McpDropdown';
 import { state } from '@/state/chat';
 import SenderAttachments from '../SenderAttachments';
 import ModeSelect from './ModeSelect';
+import ModelSelect from './ModelSelect';
 
 type ActionsComponents = {
   SendButton: React.ComponentType<ButtonProps>;
@@ -25,6 +26,7 @@ const SenderFooter: React.FC<{ components: ActionsComponents }> = ({
     <Flex justify="space-between" align="center">
       <Flex gap="small" align="center">
         <ModeSelect />
+        <ModelSelect />
         <Divider type="vertical" />
         <McpDropdown />
       </Flex>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -79,6 +79,10 @@
     "sendMessage": "Send Message",
     "thinking": "Thinking...",
     "stopGenerating": "Stop Generating",
+    "selectModel": "Select model",
+    "searchModel": "Search models",
+    "noModels": "No models available",
+    "noModelsFound": "No models found",
     "inputPlaceholder": "Input @ to use skills or input / to use commands"
   },
   "prompts": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -79,6 +79,10 @@
     "sendMessage": "发送消息",
     "thinking": "思考中...",
     "stopGenerating": "停止生成",
+    "selectModel": "选择模型",
+    "searchModel": "搜索模型",
+    "noModels": "暂无模型",
+    "noModelsFound": "未找到模型",
     "inputPlaceholder": "输入 @ 使用技能，或输入 / 使用指令"
   },
   "prompts": {


### PR DESCRIPTION
### Add model selection dropdown to chat sender

Introduce ModelSelect component with provider-grouped model options, loading states, and i18n
support for better user experience in model selection.
<img width="1728" height="957" alt="image" src="https://github.com/user-attachments/assets/8c5eb519-5599-4031-99bd-0de073f5af21" />
